### PR TITLE
Allow headers on scheduled messages

### DIFF
--- a/src/MassTransit.QuartzIntegration/ScheduleMessageConsumer.cs
+++ b/src/MassTransit.QuartzIntegration/ScheduleMessageConsumer.cs
@@ -74,6 +74,7 @@ namespace MassTransit.QuartzIntegration
                 .UsingJobData("RequestId", context.RequestId)
                 .UsingJobData("ConversationId", context.ConversationId)
                 .UsingJobData("CorrelationId", context.CorrelationId)
+                .UsingJobData("HeadersAsJson", JsonConvert.SerializeObject(context.Headers))
                 .UsingJobData("ExpirationTime",
                     context.ExpirationTime.HasValue ? context.ExpirationTime.Value.ToString() : "")
                 .UsingJobData("Network", context.Network)

--- a/src/MassTransit.QuartzIntegration/ScheduledMessageContext.cs
+++ b/src/MassTransit.QuartzIntegration/ScheduledMessageContext.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.QuartzIntegration
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using Context;
     using Serialization.Custom;
@@ -38,6 +39,12 @@ namespace MassTransit.QuartzIntegration
             {
                 writer.Write(_body);
             }
+        }
+
+        public void SetHeaders(IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            foreach (var entry in headers)
+                SetHeader(entry.Key, entry.Value);
         }
 
         public bool TryGetContext<T>(out IBusPublishContext<T> context)

--- a/src/MassTransit.QuartzIntegration/ScheduledMessageJob.cs
+++ b/src/MassTransit.QuartzIntegration/ScheduledMessageJob.cs
@@ -13,8 +13,10 @@
 namespace MassTransit.QuartzIntegration
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
     using Logging;
+    using Newtonsoft.Json;
     using Quartz;
 
 
@@ -45,6 +47,7 @@ namespace MassTransit.QuartzIntegration
         public string CorrelationId { get; set; }
         public string Network { get; set; }
         public int RetryCount { get; set; }
+        public string HeadersAsJson { get; set; }
 
         public void Execute(IJobExecutionContext context)
         {
@@ -79,6 +82,7 @@ namespace MassTransit.QuartzIntegration
             context.SetResponseAddress(ToUri(ResponseAddress));
             context.SetFaultAddress(ToUri(FaultAddress));
 
+            SetHeaders(context);
             context.SetMessageId(MessageId);
             context.SetRequestId(RequestId);
             context.SetConversationId(ConversationId);
@@ -92,6 +96,15 @@ namespace MassTransit.QuartzIntegration
             context.SetContentType(ContentType);
 
             return context;
+        }
+
+        void SetHeaders(ScheduledMessageContext context)
+        {
+            if (string.IsNullOrEmpty(HeadersAsJson))
+                return;
+
+            var headers = JsonConvert.DeserializeObject<IEnumerable<KeyValuePair<string, string>>>(HeadersAsJson);
+            context.SetHeaders(headers);
         }
 
         static Uri ToUri(string s)

--- a/src/MassTransit.Scheduling/ScheduleMessageExtensions.cs
+++ b/src/MassTransit.Scheduling/ScheduleMessageExtensions.cs
@@ -123,13 +123,14 @@ namespace MassTransit.Scheduling
         /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
         /// <param name="scheduledTime">The time when the message should be sent to the endpoint</param>
         /// <param name="message">The message to send</param>
+        /// <param name="contextCallback">Optional: A callback that gives the caller access to the publish context.</param>
         /// <returns>A handled to the scheduled message</returns>
-        public static ScheduledMessage<T> ScheduleMessage<T>(this IServiceBus bus, Uri destinationAddress, DateTime scheduledTime, T message)
+        public static ScheduledMessage<T> ScheduleMessage<T>(this IServiceBus bus, Uri destinationAddress, DateTime scheduledTime, T message, Action<IPublishContext<ScheduleMessage<T>>> contextCallback = null)
             where T : class
         {
             var command = new ScheduleMessageCommand<T>(scheduledTime, destinationAddress, message);
 
-            bus.Publish<ScheduleMessage<T>>(command);
+            bus.Publish<ScheduleMessage<T>>(command, contextCallback ?? (c => {}));
 
             return new ScheduledMessageHandle<T>(command.CorrelationId, command.ScheduledTime, command.Destination,
                 command.Payload);
@@ -175,11 +176,12 @@ namespace MassTransit.Scheduling
         /// <param name="bus">The bus from which the scheduled message command should be published</param>
         /// <param name="scheduledTime">The time when the message should be sent to the endpoint</param>
         /// <param name="message">The message to send</param>
+        ///  /// <param name="contextCallback">Optional: A callback that gives the caller access to the publish context.</param>
         /// <returns>A handled to the scheduled message</returns>
-        public static ScheduledMessage<T> ScheduleMessage<T>(this IServiceBus bus, DateTime scheduledTime, T message)
+        public static ScheduledMessage<T> ScheduleMessage<T>(this IServiceBus bus, DateTime scheduledTime, T message, Action<IPublishContext<ScheduleMessage<T>>> contextCallback = null)
             where T : class
         {
-            return ScheduleMessage(bus, bus.Endpoint.Address.Uri, scheduledTime, message);
+            return ScheduleMessage(bus, bus.Endpoint.Address.Uri, scheduledTime, message, contextCallback);
         }
 
         /// <summary>


### PR DESCRIPTION
Extended Schedule extension methods to allow context callbacks (more for testing, we use interceptors for headers)
Passing any headers from the schedule context to the message context when it is finally sent.
Added a test
