### PR TITLE
update setup_sql_server.sql

### DIFF
--- a/setup_sql_server.sql
+++ b/setup_sql_server.sql
@@ -355,3 +355,7 @@ CREATE INDEX IDX_QRTZ_FT_JG ON QRTZ_FIRED_TRIGGERS(SCHED_NAME,JOB_GROUP)
 CREATE INDEX IDX_QRTZ_FT_T_G ON QRTZ_FIRED_TRIGGERS(SCHED_NAME,TRIGGER_NAME,TRIGGER_GROUP)
 CREATE INDEX IDX_QRTZ_FT_TG ON QRTZ_FIRED_TRIGGERS(SCHED_NAME,TRIGGER_GROUP)
 GO
+                                                                                                                  
+                                                                                                                  
+                                                                                                                  ALTER TABLE QRTZ_FIRED_TRIGGERS ADD SCHED_TIME BIGINT NOT NULL;
+                                                                                                                  Go


### PR DESCRIPTION
When you run this script and then run MassTransit.QuartzService, you receive "Couldn't acquire next trigger: Invalid column name 'SCHED_TIME'" error.
according to following links, we should add new column named SCHED_TIME.

https://github.com/quartz-scheduler/quartz/issues/231
http://www.quartz-scheduler.org/documentation/quartz-2.2.x/new-in-quartz-2_2.html